### PR TITLE
Adding Tiff stack support

### DIFF
--- a/documentation/capture.md
+++ b/documentation/capture.md
@@ -182,6 +182,32 @@ Loads all images from the specified folder as frames. The images are loaded in a
 
 ---
 
+### `load_tiff_images_as_frames(capture_speed_in_fps=DEFAULT_CAPTURE_SPEED_IN_FPS, pixel_scale_factor=DEFAULT_PIXEL_SCALE_FACTOR, scale_units=DEFAULT_SCALE_UNITS, is_store_video_frames=True, store_images_path=DEFAULT_STORE_IMAGE_FILE_DIRECTORY) -> list`
+
+**Description:**  
+Loads TIFF images as frames from the specified file.
+
+**Arguments:**
+
+| Name                   | Type  | Explanation                                                                                       | Optional | Default Value                             |
+|------------------------|-------|---------------------------------------------------------------------------------------------------|----------|-------------------------------------------|
+| `file_name`            | `str` | The name of the TIFF file.                                                                        | No       | N/A                                       |
+| `capture_speed_in_fps` | `int` | The capture speed in frames per second.                                                          | Yes      | `DEFAULT_CAPTURE_SPEED_IN_FPS`           |
+| `pixel_scale_factor`   | `float`| The pixel scale factor.                                                                           | Yes      | `DEFAULT_PIXEL_SCALE_FACTOR`              |
+| `scale_units`          | `str` | The scale units.                                                                                  | Yes      | `DEFAULT_SCALE_UNITS`                     |
+| `is_store_video_frames`| `bool`| Flag indicating whether to save the extracted frames as images.                                   | Yes      | `False`                                   |
+| `store_images_path`    | `str` | Directory path where the frames should be stored if saving is enabled.                           | Yes      | `DEFAULT_STORE_IMAGE_FILE_DIRECTORY`      |
+
+**Returns:**
+
+- `list`: A list of loaded frames as NumPy arrays.
+
+**Errors:**
+
+- **`FileNotFoundError`**: Raised if the specified folder is not found.
+
+---
+
 ### `set_properties(pixel_scale_factor: float = DEFAULT_PIXEL_SCALE_FACTOR, scale_units: str = DEFAULT_SCALE_UNITS, capture_speed_in_fps: int = None) -> None`
 
 **Description:**  

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (this_directory / "pypi-description.md").read_text(encoding="
 
 setup(
     name='RABiTPy',
-    version='1.1.0',
+    version='1.2.0',
     packages=find_packages(),
     install_requires=[
         # Add your package dependencies here

--- a/walkthrough.ipynb
+++ b/walkthrough.ipynb
@@ -309,6 +309,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "##### Alternatively - Load Tiff stack\n",
+    "\n",
+    "Alternatively, you can load the tiff stack images using the function shown below (instead of load and process). In this example, \"frames\" is the sub folder name where the individual images are stored inside the main directory you provided (input_files was default set in this case). For instance, the path could be `input_files/frames/.......`.\n",
+    "\n",
+    "```python\n",
+    "frames = capture.load_tiff_images_as_frames(file_name='FJ.tif',pixel_scale_factor=0.166, scale_units='um', is_store_video_frames=True, store_images_path='frames')\n",
+    "```\n",
+    "\n",
+    "This function allows you to specify the folder containing the frames, along with parameters such as the capture speed in frames per second (FPS) and the pixel scale factor, scale units as above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Step 2: Identify\n",
     "\n",
     "In this step, we apply either thresholding or AI-based methods to detect the cells present in each of the frames loaded earlier. To initiate the `Identify` class, you must input the previously created `Capture` object. This object serves as the foundation for identifying and analyzing the elements within the frames."


### PR DESCRIPTION
This pull request introduces a new feature to load TIFF images as frames in the `Capture` class, along with corresponding updates to the documentation, examples, and versioning. The changes enhance the functionality of the library by allowing users to process TIFF stacks directly and save frames as images if needed.

### New Feature: Load TIFF Images as Frames
* Added a `load_tiff_images_as_frames` method to the `Capture` class in `RABiTPy/capture.py`. This method allows loading TIFF stack images as frames, with options to specify capture speed, pixel scaling, and whether to save extracted frames to a directory. It raises a `FileNotFoundError` if the specified file is not found.
* Imported the `tifffile` library in `RABiTPy/capture.py` to support TIFF file processing.

### Documentation Updates
* Added documentation for the `load_tiff_images_as_frames` method in `documentation/capture.md`, detailing its purpose, arguments, return type, and possible errors.

### Example Usage
* Updated `walkthrough.ipynb` to include an example of using the `load_tiff_images_as_frames` method, demonstrating how to load TIFF stacks and save frames.

### Version Update
* Incremented the package version in `setup.py` from `1.1.0` to `1.2.0` to reflect the addition of the new feature.